### PR TITLE
Fix multiple saved Covers / user form with empty fields

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -51,6 +51,10 @@ mainPage.innerHTML = `
 
 function saveMakeOwnCover() {
   event.preventDefault()
+  fixBrokenCover();
+  if (fixBrokenCover()) {
+    return alert("Can't create new cover without all values in each field. Try again!");
+  }
   currentCover = new Cover(userCover.value, userTitle.value, userDescriptor1.value, userDescriptor2.value)
 
   mainPage.innerHTML = `
@@ -67,7 +71,6 @@ function saveMakeOwnCover() {
     mainPage.classList.remove('hidden');
     saveCoverButton.classList.remove('hidden');
     randomCoverButton.classList.remove('hidden');
-    fixBrokenCover();
 };
 
 function showMakeOwnCover() {
@@ -113,6 +116,7 @@ function saveCover(){
 function displayAllSavedCovers() {
   viewSavedSection.classList.remove('hidden');
   homeView.classList.add('hidden');
+  savedCoversSection.innerHTML = '';
 
   for (var i = 0; i < savedCovers.length; i++){
     savedCoversSection.innerHTML += `
@@ -128,8 +132,8 @@ function displayAllSavedCovers() {
 };
 
 function fixBrokenCover() {
-  if (userCover.value === "" && userTitle.value === "" && userDescriptor1.value === "" && userDescriptor2.value === ""){
-  alert("Can't create new cover without all values in each field. Try again!")
-  window.location.reload();
+  if (userCover.value === "" || userTitle.value === "" || userDescriptor1.value === "" || userDescriptor2.value === ""){
+  // window.location.reload();
+  return true;
   }
 };


### PR DESCRIPTION
### What does this PR do?
- Fixed bug that was showing multiple covers inside the 'view saved covers' page
- Fixed bug that when user filled out form incorrectly it would show broken images
### What does it fix?
- Fixed bug that was showing multiple covers inside the 'view saved covers' page
- Fixed bug that when user filled out form incorrectly it would show broken images
### Is this a feature or a fix?
- Fix
### Where should the reviewer start?
- Line 134-139 /54-57
### How should this be tested?
-  Open app > save cover > view cover > save cover > view cover.  There shouldnt be any duplicate covers being shown. 
- Open app > "Make your own cover" > fill out (0-1) line and hit submit button. Should not create broken  image, rather, just stay on page and allow user to fill out the rest of the form. 